### PR TITLE
Prevent use of nan 2.8.0 which breaks nodesodium compilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "description": "Lib Sodium port for node.js",
   "dependencies": {
-    "nan": "^2.2.1"
+    "nan": ">=2.2.1 <2.8.0"
   },
   "devDependencies": {
     "mdextract": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "description": "Lib Sodium port for node.js",
   "dependencies": {
-    "nan": ">=2.2.1 <2.8.0"
+    "nan": "2.2.1"
   },
   "devDependencies": {
     "mdextract": "^1.0.0",


### PR DESCRIPTION
Fixes compilation failure, see https://github.com/paixaop/node-sodium/issues/124